### PR TITLE
Fixed crash when using player in iOS 9.0

### DIFF
--- a/YTPlayerView/YTPlayerView.m
+++ b/YTPlayerView/YTPlayerView.m
@@ -913,7 +913,12 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
     config.userContentController = wkUController;
     config.applicationNameForUserAgent = @"app-embedded-web-view";
     config.allowsInlineMediaPlayback = YES;
-    config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+    if (@available(iOS 10.0, *)) {
+         config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+    }
+    else {
+         config.mediaPlaybackRequiresUserAction = NO;
+    }
     WKWebView *webView = [[WKWebView alloc] initWithFrame:self.bounds configuration:config];
     webView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     webView.scrollView.scrollEnabled = NO;


### PR DESCRIPTION
Issue: The method mediaTypesRequiringUserActionForPlayback throws a selector not foundm since it was introduced in 10.0, using the older deprecated method
Fix: Check os version and use appropriate method